### PR TITLE
MOTECH-2857 Dhis2 module connection leak - work I have done until now

### DIFF
--- a/dhis2/src/main/java/org/motechproject/dhis2/service/impl/SyncServiceImpl.java
+++ b/dhis2/src/main/java/org/motechproject/dhis2/service/impl/SyncServiceImpl.java
@@ -192,11 +192,14 @@ public class SyncServiceImpl implements SyncService {
 
         for (ProgramStageDataElementDto programStageDataElementDto : programStageDataElementDtos) {
             DataElementDto dataElementDto = programStageDataElementDto.getDataElement();
-            DataElement dataElement = dataElementService.findById(dataElementDto.getId());
-            if (dataElement == null) {
-                dataElement = dataElementService.createFromDetails(dataElementDto);
+            // These changes were made to avoid NPE during sync (already fixed in MOTECH-2030)
+            if (dataElementDto != null) {
+                DataElement dataElement = dataElementService.findById(dataElementDto.getId());
+                if (dataElement == null) {
+                    dataElement = dataElementService.createFromDetails(dataElementDto);
+                }
+                dataElements.add(dataElement);
             }
-            dataElements.add(dataElement);
         }
         return dataElements;
     }


### PR DESCRIPTION
This PR is a proposition to fix bug mentioned in Motech Developer Google Group (https://groups.google.com/forum/#!topic/motech-dev/egp1KWfvyM0) but it is not finished!

As Paweł and Samantha said in discussion, I tried to reproduce the error with mocked server acting as dhis2 one that just goes into a endless loop without closing the connection.

To reproduce the exception I did as followed:
- created task with Create Tracked Entity Instance action
- multiplied (through changes in code) number of created events when executing new task trigger (for example, I put https://github.com/filgomul/motech/blob/274cb4274d3d6d7eb4e10c1fa27c936afcc244d5/platform/mds/mds/src/main/java/org/motechproject/mds/service/DefaultMotechDataService.java#L144 in a loop and set CREATE MotechPermission as a trigger).

In createTrackedEntityInstance function there is commented out code showing how redirect request to the fake server.

I managed to get blocking request problem, and setting socket timeout seems to deal with this problem rather okay.

I couldn't fix the problem with CLOSE_WAIT connections Samantha mentioned in first post. There was no problem while working with dhis2 server, but consuming responses and closing requests didn't seem to work on SimpleHttpServer.
